### PR TITLE
Adding delimiter specification

### DIFF
--- a/scripts/retrieve_metadata_from_database.py
+++ b/scripts/retrieve_metadata_from_database.py
@@ -103,7 +103,7 @@ class OutputFile:
         None.
 
         '''
-        metadataCatalogue = pd.read_csv('../../drupal8multisite/web/export_aen_2021_11_08.csv')
+        metadataCatalogue = pd.read_csv('../../drupal8multisite/web/export_aen_2021_11_08.csv', delimiter = '|')
         
         self.inputFile.data.dropna(subset = ['eventID'], inplace = True)
         


### PR DESCRIPTION
The CSV pulled into the Drupal site has been converted to have a '|' delimiter. When read in by default using pandas 'read_csv' this fails, so specifying the delimiter explicitly.